### PR TITLE
feat(theme): M3 OLED system theme — closes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Internal / admin UI (**staff console**). This repo targets **web only** (no mobi
 
 **UI / UX requirements:** [`docs/frontend-requirements.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/frontend-requirements.md) in the monorepo (Material 3, OLED `#000000` scaffold, System vs Market differences).
 
+**Theme:** `lib/theme/system_theme.dart` — `buildZhuchkaSystemTheme()`, `ZhuchkaSystemTokens` (`oledBlack` for scaffold).
+
 **Workflow:** one issue → one branch from `dev` → PR into `dev` (Git workflow for the monorepo: [`docs/git-workflow.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/git-workflow.md)).
 
 ---

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'theme/system_theme.dart';
+
 void main() {
   runApp(const MyApp());
 }
@@ -11,53 +13,34 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Zhuchka System',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
-      ),
-      home: const MyHomePage(title: 'Zhuchka System'),
+      theme: buildZhuchkaSystemTheme(),
+      themeMode: ThemeMode.dark,
+      home: const SystemHomePage(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() => _counter++);
-  }
+/// Bootstrap home until routing and shell land (issue #2).
+class SystemHomePage extends StatelessWidget {
+  const SystemHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
+        title: const Text('Zhuchka System'),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Staff console — M3 theme baseline (OLED #000000 scaffold). '
+            'See docs/frontend-requirements.md in the monorepo.',
+            style: theme.textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/theme/system_theme.dart
+++ b/lib/theme/system_theme.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+/// Accent seed for [ColorScheme] (Material 3 dark), aligned with Market for one design family.
+///
+/// UI bar: [`docs/frontend-requirements.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/frontend-requirements.md)
+/// (OLED `#000000` scaffold, M3 surfaces; System may use denser layouts later).
+const Color kZhuchkaSystemBrandSeed = Color(0xFF2D2640);
+
+/// Project surface tokens layered on Material 3.
+@immutable
+class ZhuchkaSystemTokens extends ThemeExtension<ZhuchkaSystemTokens> {
+  const ZhuchkaSystemTokens({
+    this.oledBlack = const Color(0xFF000000),
+  });
+
+  /// Root scaffold / app background — strict OLED black (spec §2.1).
+  final Color oledBlack;
+
+  @override
+  ZhuchkaSystemTokens copyWith({Color? oledBlack}) {
+    return ZhuchkaSystemTokens(oledBlack: oledBlack ?? this.oledBlack);
+  }
+
+  @override
+  ZhuchkaSystemTokens lerp(ThemeExtension<ZhuchkaSystemTokens>? other, double t) {
+    if (other is! ZhuchkaSystemTokens) return this;
+    return ZhuchkaSystemTokens(
+      oledBlack: Color.lerp(oledBlack, other.oledBlack, t)!,
+    );
+  }
+}
+
+/// Dark-only staff console theme: M3, OLED black scaffold, generated [ColorScheme].
+ThemeData buildZhuchkaSystemTheme() {
+  final colorScheme = ColorScheme.fromSeed(
+    seedColor: kZhuchkaSystemBrandSeed,
+    brightness: Brightness.dark,
+  );
+
+  const tokens = ZhuchkaSystemTokens();
+
+  return ThemeData(
+    useMaterial3: true,
+    brightness: Brightness.dark,
+    colorScheme: colorScheme,
+    scaffoldBackgroundColor: tokens.oledBlack,
+    extensions: const [tokens],
+    appBarTheme: AppBarTheme(
+      backgroundColor: colorScheme.surfaceContainerHighest,
+      surfaceTintColor: Colors.transparent,
+      foregroundColor: colorScheme.onSurface,
+    ),
+  );
+}

--- a/test/system_theme_test.dart
+++ b/test/system_theme_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zhuchka_system/theme/system_theme.dart';
+
+void main() {
+  group('buildZhuchkaSystemTheme', () {
+    test('uses Material 3 and dark brightness', () {
+      final theme = buildZhuchkaSystemTheme();
+      expect(theme.useMaterial3, isTrue);
+      expect(theme.brightness, Brightness.dark);
+      expect(theme.colorScheme.brightness, Brightness.dark);
+    });
+
+    test('scaffold background is OLED black per frontend-requirements', () {
+      final theme = buildZhuchkaSystemTheme();
+      expect(theme.scaffoldBackgroundColor, const Color(0xFF000000));
+      final tokens = theme.extension<ZhuchkaSystemTokens>();
+      expect(tokens, isNotNull);
+      expect(tokens!.oledBlack, const Color(0xFF000000));
+    });
+
+    testWidgets('ThemeData drives scaffold background for Scaffold', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: buildZhuchkaSystemTheme(),
+          home: Builder(
+            builder: (context) {
+              expect(
+                Theme.of(context).scaffoldBackgroundColor,
+                const Color(0xFF000000),
+              );
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,11 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:zhuchka_system/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('home shows app title and baseline copy', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Zhuchka System'), findsOneWidget);
+    expect(find.textContaining('Staff console'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- Add `lib/theme/system_theme.dart`: `ZhuchkaSystemTokens` (`oledBlack` = `#000000`), `buildZhuchkaSystemTheme()` — Material 3 dark, same brand seed as Market for one family.
- Replace default counter app with minimal `SystemHomePage` using the theme (`ThemeMode.dark`).
- Tests: theme parity with market theme tests + home smoke.
- README: pointer to theme module.

Closes #1
