### PR TITLE
feat(routing): go_router and system shell — closes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Internal / admin UI (**staff console**). This repo targets **web only** (no mobi
 
 **Theme:** `lib/theme/system_theme.dart` — `buildZhuchkaSystemTheme()`, `ZhuchkaSystemTokens` (`oledBlack` for scaffold).
 
+**Routing:** [`go_router`](https://pub.dev/packages/go_router) + shell (`lib/widgets/system_shell.dart`): `NavigationRail` — `/` (dashboard), `/lists` (placeholder), `/settings` (placeholder). Router factory: `lib/app/system_router.dart` (`createSystemRouter()`).
+
 **Workflow:** one issue → one branch from `dev` → PR into `dev` (Git workflow for the monorepo: [`docs/git-workflow.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/git-workflow.md)).
 
 ---

--- a/lib/app/system_router.dart
+++ b/lib/app/system_router.dart
@@ -1,0 +1,37 @@
+import 'package:go_router/go_router.dart';
+
+import '../screens/dashboard_screen.dart';
+import '../screens/lists_placeholder_screen.dart';
+import '../screens/settings_placeholder_screen.dart';
+import '../widgets/system_shell.dart';
+
+/// Staff console routes: dashboard and placeholders behind [SystemShell].
+GoRouter createSystemRouter() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) {
+          return SystemShell(
+            location: state.uri.path,
+            child: child,
+          );
+        },
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const DashboardScreen(),
+          ),
+          GoRoute(
+            path: '/lists',
+            builder: (context, state) => const ListsPlaceholderScreen(),
+          ),
+          GoRoute(
+            path: '/settings',
+            builder: (context, state) => const SettingsPlaceholderScreen(),
+          ),
+        ],
+      ),
+    ],
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,47 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
+import 'app/system_router.dart';
 import 'theme/system_theme.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Zhuchka System',
-      theme: buildZhuchkaSystemTheme(),
-      themeMode: ThemeMode.dark,
-      home: const SystemHomePage(),
-    );
-  }
+  State<MyApp> createState() => _MyAppState();
 }
 
-/// Bootstrap home until routing and shell land (issue #2).
-class SystemHomePage extends StatelessWidget {
-  const SystemHomePage({super.key});
+class _MyAppState extends State<MyApp> {
+  late final GoRouter _router = createSystemRouter();
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Zhuchka System'),
-      ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            'Staff console — M3 theme baseline (OLED #000000 scaffold). '
-            'See docs/frontend-requirements.md in the monorepo.',
-            style: theme.textTheme.bodyLarge,
-            textAlign: TextAlign.center,
-          ),
-        ),
-      ),
+    return MaterialApp.router(
+      title: 'Zhuchka System',
+      theme: buildZhuchkaSystemTheme(),
+      themeMode: ThemeMode.dark,
+      routerConfig: _router,
     );
   }
 }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// Default home: overview until real modules ship.
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Staff console — M3 theme baseline (OLED #000000 scaffold). '
+            'See docs/frontend-requirements.md in the monorepo.',
+            style: theme.textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/lists_placeholder_screen.dart
+++ b/lib/screens/lists_placeholder_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder until table views and filters (issue #7).
+class ListsPlaceholderScreen extends StatelessWidget {
+  const ListsPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Lists'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Lists and filters — placeholder (issue #7).',
+            style: theme.textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_placeholder_screen.dart
+++ b/lib/screens/settings_placeholder_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder until settings and profile are wired.
+class SettingsPlaceholderScreen extends StatelessWidget {
+  const SettingsPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'Settings — placeholder.',
+            style: theme.textTheme.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/system_shell.dart
+++ b/lib/widgets/system_shell.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+/// Primary navigation + [child] from [GoRouter] [ShellRoute] (staff console).
+class SystemShell extends StatelessWidget {
+  const SystemShell({
+    required this.location,
+    required this.child,
+    super.key,
+  });
+
+  final String location;
+  final Widget child;
+
+  int get _selectedIndex {
+    if (location.startsWith('/lists')) return 1;
+    if (location.startsWith('/settings')) return 2;
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Row(
+        children: [
+          NavigationRail(
+            selectedIndex: _selectedIndex,
+            onDestinationSelected: (index) {
+              switch (index) {
+                case 0:
+                  context.go('/');
+                case 1:
+                  context.go('/lists');
+                case 2:
+                  context.go('/settings');
+              }
+            },
+            labelType: NavigationRailLabelType.all,
+            destinations: const [
+              NavigationRailDestination(
+                icon: Icon(Icons.dashboard_outlined),
+                selectedIcon: Icon(Icons.dashboard),
+                label: Text('Dashboard'),
+              ),
+              NavigationRailDestination(
+                icon: Icon(Icons.table_rows_outlined),
+                selectedIcon: Icon(Icons.table_rows),
+                label: Text('Lists'),
+              ),
+              NavigationRailDestination(
+                icon: Icon(Icons.settings_outlined),
+                selectedIcon: Icon(Icons.settings),
+                label: Text('Settings'),
+              ),
+            ],
+          ),
+          const VerticalDivider(width: 1),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -107,6 +120,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -210,4 +231,4 @@ packages:
     version: "15.0.2"
 sdks:
   dart: ">=3.11.3 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^14.6.2
 
 dev_dependencies:
   flutter_test:

--- a/test/router_shell_test.dart
+++ b/test/router_shell_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:zhuchka_system/main.dart';
+
+void main() {
+  testWidgets('NavigationRail opens lists placeholder', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+    expect(find.text('Dashboard'), findsWidgets);
+
+    await tester.tap(find.text('Lists'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Lists'), findsWidgets);
+    expect(
+      find.textContaining('Lists and filters'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('NavigationRail opens settings placeholder', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Settings'), findsWidgets);
+    expect(find.textContaining('Settings — placeholder'), findsOneWidget);
+  });
+
+  testWidgets('returns to dashboard from lists', (tester) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lists'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Dashboard'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Staff console'), findsOneWidget);
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,9 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zhuchka_system/main.dart';
 
 void main() {
-  testWidgets('home shows app title and baseline copy', (WidgetTester tester) async {
+  testWidgets('dashboard shows baseline copy', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
-    expect(find.text('Zhuchka System'), findsOneWidget);
+    await tester.pumpAndSettle();
+    expect(find.text('Dashboard'), findsWidgets);
     expect(find.textContaining('Staff console'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- Add `go_router` and `createSystemRouter()` with `ShellRoute` wrapping `SystemShell` (`NavigationRail`: Dashboard, Lists, Settings).
- Routes: `/` dashboard (previous home copy), `/lists` and `/settings` placeholders (refs issue #7 for tables).
- `MaterialApp.router` in `main.dart`.
- Widget tests for rail navigation and dashboard smoke.
- README: routing section.

Closes #2
