### PR TITLE
ci: GitHub Actions Flutter analyze, test, build web — closes #5

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -1,0 +1,42 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [dev, master, main]
+  pull_request:
+    branches: [dev, master, main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flutter-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze-test-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Enable web
+        run: flutter config --enable-web
+
+      - name: Dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+      - name: Test
+        run: flutter test
+      - name: Build web (release)
+        run: flutter build web --release

--- a/README.md
+++ b/README.md
@@ -83,4 +83,6 @@ Document new variables in this README when they are introduced.
 
 ## CI
 
-Flutter checks for this package are also run from the **monorepo** GitHub Actions when the `frontend/system` submodule pointer is updated (see root `.github/workflows` in `ZhuchkaKeyboards`).
+On push/PR to `dev`, `main`, or `master`, `.github/workflows/flutter_ci.yml` runs `flutter analyze`, `flutter test`, and `flutter build web --release` on Ubuntu (stable SDK).
+
+The **monorepo** `ZhuchkaKeyboards` also runs analyze + test for `frontend/system` when the submodule pointer is updated (see `.github/workflows/flutter-apps-reusable.yml`).


### PR DESCRIPTION
## Summary

- Add `.github/workflows/flutter_ci.yml` (same steps as `frontend/market`): analyze, test, `flutter build web --release` on push/PR to `dev` / `main` / `master`.
- README: document standalone workflow + monorepo reusable job.

Closes #5
