### PR TITLE
feat(http): Dio, SystemApiException, GET retry — closes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Internal / admin UI (**staff console**). This repo targets **web only** (no mobi
 
 **Routing:** [`go_router`](https://pub.dev/packages/go_router) + shell (`lib/widgets/system_shell.dart`): `NavigationRail` — `/` (dashboard), `/lists` (placeholder), `/settings` (placeholder). Router factory: `lib/app/system_router.dart` (`createSystemRouter()`).
 
+**HTTP:** [`dio`](https://pub.dev/packages/dio) — `createSystemDio()` (`lib/http/system_dio.dart`): timeouts, retry for **GET** on transient failures (`RetryInterceptor`); API errors → `SystemApiException` via `systemApiExceptionFromDio()` (`lib/http/dio_error_mapper.dart`).
+
 **Workflow:** one issue → one branch from `dev` → PR into `dev` (Git workflow for the monorepo: [`docs/git-workflow.md`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/dev/docs/git-workflow.md)).
 
 ---
@@ -72,12 +74,17 @@ dart analyze
 
 ## Environment and configuration
 
-There is **no** required `dart-define` or `.env` file in the bootstrap app yet. When the HTTP client and auth base URL are wired in, prefer:
+Build-time values use `--dart-define` (and `flutter build web --dart-define=...`):
 
-- **`--dart-define=API_BASE_URL=...`** (and similar keys) for build-time configuration, **or**
-- documented runtime configuration if your deployment requires it.
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `API_BASE_URL` | Base URL for `createSystemDio()` (gateway / auth / future BFF) | `http://127.0.0.1:8000` |
 
-Document new variables in this README when they are introduced.
+Example:
+
+```bash
+flutter run -d chrome --dart-define=API_BASE_URL=https://api.example.com
+```
 
 ---
 

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,0 +1,10 @@
+/// Build-time configuration (`--dart-define`).
+class AppConfig {
+  AppConfig._();
+
+  /// Default backend base for staff API calls (auth gateway or future BFF).
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://127.0.0.1:8000',
+  );
+}

--- a/lib/http/dio_error_mapper.dart
+++ b/lib/http/dio_error_mapper.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+
+import 'system_api_exception.dart';
+
+/// Maps [DioException] to [SystemApiException] using JSON bodies when present
+/// (OAuth-style `error` / `error_description`, FastAPI `detail`).
+SystemApiException systemApiExceptionFromDio(DioException e) {
+  final res = e.response;
+  if (res != null) {
+    final status = res.statusCode ?? 0;
+    final map = _tryJsonMap(res.data);
+    if (map.isNotEmpty) {
+      final err = map['error']?.toString();
+      final desc = map['error_description']?.toString();
+      final detail = map['detail'];
+      if (err != null && err.isNotEmpty) {
+        return SystemApiException(
+          desc != null && desc.isNotEmpty ? '$err: $desc' : err,
+          status,
+        );
+      }
+      if (detail != null) {
+        return SystemApiException(_detailToMessage(detail), status);
+      }
+      final msg = map['message']?.toString();
+      if (msg != null && msg.isNotEmpty) {
+        return SystemApiException(msg, status);
+      }
+    }
+    return SystemApiException(e.message ?? 'error', status);
+  }
+  return SystemApiException(e.message ?? 'network error', 0);
+}
+
+String _detailToMessage(dynamic detail) {
+  if (detail is String) {
+    return detail;
+  }
+  if (detail is List) {
+    return detail.map((e) => e.toString()).join(', ');
+  }
+  if (detail is Map) {
+    return jsonEncode(detail);
+  }
+  return detail.toString();
+}
+
+Map<String, dynamic> _tryJsonMap(dynamic data) {
+  if (data is Map<String, dynamic>) {
+    return data;
+  }
+  if (data is Map) {
+    return Map<String, dynamic>.from(data);
+  }
+  if (data is String && data.isNotEmpty) {
+    try {
+      final decoded = jsonDecode(data);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      if (decoded is Map) {
+        return Map<String, dynamic>.from(decoded);
+      }
+    } catch (_) {}
+  }
+  return {};
+}

--- a/lib/http/retry_interceptor.dart
+++ b/lib/http/retry_interceptor.dart
@@ -1,0 +1,52 @@
+import 'package:dio/dio.dart';
+
+/// Retries **GET** requests on transient network failures (timeouts, connection errors).
+///
+/// Mutating requests (POST, etc.) are not retried to avoid duplicate side effects.
+class RetryInterceptor extends Interceptor {
+  RetryInterceptor({required this.dio, this.maxRetries = 2});
+
+  final Dio dio;
+  final int maxRetries;
+
+  @override
+  Future<void> onError(
+    DioException err,
+    ErrorInterceptorHandler handler,
+  ) async {
+    if (err.requestOptions.method != 'GET') {
+      return handler.next(err);
+    }
+    if (!_isRetryable(err)) {
+      return handler.next(err);
+    }
+    final extra = err.requestOptions.extra;
+    final retry = (extra['retryCount'] as int?) ?? 0;
+    if (retry >= maxRetries) {
+      return handler.next(err);
+    }
+    extra['retryCount'] = retry + 1;
+    await Future<void>.delayed(Duration(milliseconds: 200 * (retry + 1)));
+    try {
+      final response = await dio.fetch<Object?>(err.requestOptions);
+      return handler.resolve(response);
+    } on DioException catch (e) {
+      return handler.next(e);
+    }
+  }
+
+  bool _isRetryable(DioException err) {
+    switch (err.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.connectionError:
+        return true;
+      case DioExceptionType.badResponse:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.cancel:
+      case DioExceptionType.unknown:
+        return false;
+    }
+  }
+}

--- a/lib/http/system_api_exception.dart
+++ b/lib/http/system_api_exception.dart
@@ -1,0 +1,10 @@
+/// Error from a staff-console HTTP API (JSON body or network failure).
+class SystemApiException implements Exception {
+  SystemApiException(this.message, this.statusCode);
+
+  final String message;
+  final int statusCode;
+
+  @override
+  String toString() => 'SystemApiException($statusCode): $message';
+}

--- a/lib/http/system_dio.dart
+++ b/lib/http/system_dio.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+import '../config/app_config.dart';
+import 'retry_interceptor.dart';
+
+/// Shared [Dio] for staff-console APIs: timeouts, GET retries on transient failures.
+Dio createSystemDio() {
+  final base = AppConfig.apiBaseUrl.replaceAll(RegExp(r'/+$'), '');
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: base,
+      connectTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 30),
+      sendTimeout: const Duration(seconds: 30),
+    ),
+  );
+  dio.interceptors.add(RetryInterceptor(dio: dio));
+  return dio;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,6 +49,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   fake_async:
     dependency: transitive
     description:
@@ -88,6 +104,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
+  http_mock_adapter:
+    dependency: "direct dev"
+    description:
+      name: http_mock_adapter
+      sha256: "46399c78bd4a0af071978edd8c502d7aeeed73b5fb9860bca86b5ed647a63c1b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -120,6 +152,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      sha256: "25aee487596a6257655a1e091ec2ae66bc30e7af663592cc3a27e6591e05035c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   logging:
     dependency: transitive
     description:
@@ -152,6 +192,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -213,6 +261,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -229,6 +285,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.11.3 <4.0.0"
   flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  dio: ^5.7.0
   go_router: ^14.6.2
 
 dev_dependencies:
@@ -46,6 +47,7 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
+  http_mock_adapter: ^0.6.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/http/dio_error_mapper_test.dart
+++ b/test/http/dio_error_mapper_test.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+
+import 'package:zhuchka_system/http/dio_error_mapper.dart';
+import 'package:zhuchka_system/http/system_api_exception.dart';
+
+void main() {
+  test('maps FastAPI detail string', () async {
+    final dio = Dio(BaseOptions(baseUrl: 'http://mock.test'));
+    final adapter = DioAdapter(dio: dio);
+    dio.httpClientAdapter = adapter;
+
+    adapter.onGet(
+      '/x',
+      (server) => server.reply(
+        422,
+        <String, dynamic>{'detail': 'validation failed'},
+      ),
+    );
+
+    try {
+      await dio.get<Object>('/x');
+      fail('expected DioException');
+    } on DioException catch (e) {
+      final ex = systemApiExceptionFromDio(e);
+      expect(ex, isA<SystemApiException>());
+      expect(ex.message, 'validation failed');
+      expect(ex.statusCode, 422);
+    }
+  });
+
+  test('maps OAuth-style error and description', () async {
+    final dio = Dio(BaseOptions(baseUrl: 'http://mock.test'));
+    final adapter = DioAdapter(dio: dio);
+    dio.httpClientAdapter = adapter;
+
+    adapter.onGet(
+      '/x',
+      (server) => server.reply(
+        400,
+        <String, dynamic>{
+          'error': 'invalid_request',
+          'error_description': 'Missing field',
+        },
+      ),
+    );
+
+    try {
+      await dio.get<Object>('/x');
+      fail('expected DioException');
+    } on DioException catch (e) {
+      final ex = systemApiExceptionFromDio(e);
+      expect(ex.message, 'invalid_request: Missing field');
+      expect(ex.statusCode, 400);
+    }
+  });
+
+  test('network error maps to status 0', () {
+    final ex = systemApiExceptionFromDio(
+      DioException(
+        requestOptions: RequestOptions(path: '/'),
+        type: DioExceptionType.connectionError,
+        message: 'Socket failed',
+      ),
+    );
+    expect(ex.statusCode, 0);
+    expect(ex.message, contains('Socket'));
+  });
+}

--- a/test/http/system_dio_test.dart
+++ b/test/http/system_dio_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http_mock_adapter/http_mock_adapter.dart';
+
+import 'package:zhuchka_system/http/system_dio.dart';
+
+void main() {
+  test('createSystemDio GET succeeds with mock adapter', () async {
+    final dio = createSystemDio();
+    final adapter = DioAdapter(dio: dio);
+    dio.httpClientAdapter = adapter;
+
+    adapter.onGet(
+      '/health/live',
+      (server) => server.reply(200, <String, dynamic>{'status': 'ok'}),
+    );
+
+    final res = await dio.get<Map<String, dynamic>>('/health/live');
+    expect(res.statusCode, 200);
+    expect(res.data?['status'], 'ok');
+  });
+}


### PR DESCRIPTION
## Summary

- `AppConfig.apiBaseUrl` (`API_BASE_URL`, default `http://127.0.0.1:8000`).
- `createSystemDio()` with timeouts + `RetryInterceptor` (GET only, same as market).
- `SystemApiException` + `systemApiExceptionFromDio()` (OAuth + FastAPI `detail` / `message`).
- Unit tests with `http_mock_adapter`.
- README: HTTP line + env table.

Closes #3
